### PR TITLE
Add theme switcher with dark mode support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { QueryProvider } from './providers/QueryProvider';
 import { XnatProvider, useXnat } from './contexts/XnatContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { Login } from './components/Login';
 import { Layout } from './components/Layout';
 import { Dashboard } from './components/Dashboard';
@@ -67,13 +68,15 @@ function AppContent() {
 
 function App() {
   return (
-    <QueryProvider>
-      <XnatProvider>
-        <Router>
-          <AppContent />
-        </Router>
-      </XnatProvider>
-    </QueryProvider>
+    <ThemeProvider>
+      <QueryProvider>
+        <XnatProvider>
+          <Router>
+            <AppContent />
+          </Router>
+        </XnatProvider>
+      </QueryProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,9 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode, type ChangeEvent } from 'react';
 import { useXnat } from '../contexts/XnatContext';
-import { 
-  User, 
-  Settings, 
-  LogOut, 
+import {
+  User,
+  Settings,
+  LogOut,
   Home,
   Folder,
   Users,
@@ -18,13 +18,16 @@ import {
   Globe,
   Plus,
   ChevronRight,
-  Star
+  Star,
+  Sun,
+  Moon
 } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { ChatWidget } from './ChatWidget';
 import type { XnatProject, XnatProjectAccess, XnatSavedSearch } from '../services/xnat-api';
+import { useTheme } from '../contexts/ThemeContext';
 
 interface LayoutProps {
   children: ReactNode;
@@ -56,6 +59,7 @@ export function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchValue, setSearchValue] = useState('');
+  const { theme, setTheme } = useTheme();
   
   // Check if we're on the viewer route to adjust layout
   const isViewerRoute = location.pathname.includes('/viewer');
@@ -132,23 +136,35 @@ export function Layout({ children }: LayoutProps) {
 
   const busyNav = projectsQuery.isLoading || accessQuery.isLoading || savedSearchQuery.isLoading;
 
+  const handleThemeChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextTheme = event.target.value === 'dark' ? 'dark' : 'light';
+    setTheme(nextTheme);
+  };
+
   return (
-    <div className={clsx("min-h-screen", isViewerRoute ? "bg-gray-100 flex flex-col" : "bg-gray-50 flex")}>
+    <div
+      className={clsx(
+        'min-h-screen text-gray-900 dark:text-gray-100',
+        isViewerRoute ? 'bg-gray-100 dark:bg-slate-900 flex flex-col' : 'bg-gray-50 dark:bg-slate-950 flex'
+      )}
+    >
       {/* Left Sidebar - Hidden on viewer route */}
       {!isViewerRoute && (
         <div className="hidden md:flex md:w-64 md:flex-col">
-          <div className="flex flex-col flex-grow bg-white border-r border-gray-200">
+          <div className="flex flex-col flex-grow border-r border-gray-200 bg-white dark:border-slate-800 dark:bg-slate-900">
             {/* Logo */}
-            <div className="flex items-center px-6 py-4 border-b border-gray-200">
-              <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
+            <div className="flex items-center border-b border-gray-200 px-6 py-4 dark:border-slate-800">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600">
                 <span className="text-white font-bold text-sm">X</span>
               </div>
             </div>
-            
+
             {/* Navigation */}
             <nav className="flex-1 px-4 py-6 space-y-6">
               <div>
-                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Navigation</p>
+                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Navigation
+                </p>
                 <div className="mt-3 space-y-2">
                   {navigation.map((item) => {
                     const isActive = location.pathname === item.href;
@@ -157,13 +173,13 @@ export function Layout({ children }: LayoutProps) {
                         key={item.name}
                         to={item.href}
                         className={clsx(
-                          'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
+                          'flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors',
                           isActive
-                            ? 'bg-blue-100 text-blue-700 border-r-2 border-blue-600'
-                            : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                            ? 'border-r-2 border-blue-600 bg-blue-100 text-blue-700 dark:border-blue-400 dark:bg-blue-950/40 dark:text-blue-200'
+                            : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-slate-800 dark:hover:text-white'
                         )}
                       >
-                        <item.icon className="w-5 h-5 mr-3" />
+                        <item.icon className="mr-3 h-5 w-5" />
                         {item.name}
                       </Link>
                     );
@@ -172,33 +188,37 @@ export function Layout({ children }: LayoutProps) {
               </div>
 
               <div>
-                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Quick Search</p>
+                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Quick Search
+                </p>
                 <form onSubmit={handleQuickSearch} className="mt-3">
                   <div className="relative">
-                    <Search className="pointer-events-none absolute inset-y-0 left-3 h-4 w-4 self-center text-gray-400" />
+                    <Search className="pointer-events-none absolute inset-y-0 left-3 h-4 w-4 self-center text-gray-400 dark:text-gray-500" />
                     <input
                       type="text"
                       value={searchValue}
                       onChange={(event) => setSearchValue(event.target.value)}
                       placeholder="Search projects, subjects…"
-                      className="w-full rounded-md border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                      className="w-full rounded-md border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-blue-400 dark:focus:ring-blue-500"
                     />
                   </div>
                 </form>
               </div>
 
               <div>
-                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Browse Projects</p>
+                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Browse Projects
+                </p>
                 <div className="mt-3 space-y-3">
                   {busyNav ? (
-                    <p className="px-3 text-xs text-gray-500">Loading project lists…</p>
+                    <p className="px-3 text-xs text-gray-500 dark:text-gray-400">Loading project lists…</p>
                   ) : (
                     <>
                       {myProjects.length > 0 && (
-                        <details className="group rounded-md border border-gray-200 bg-white">
-                          <summary className="flex cursor-pointer items-center justify-between px-3 py-2 text-sm font-medium text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400">
+                        <details className="group rounded-md border border-gray-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+                          <summary className="flex cursor-pointer items-center justify-between px-3 py-2 text-sm font-medium text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:text-gray-200">
                             <span>My Projects</span>
-                            <ChevronRight className="h-4 w-4 text-gray-400 transition group-open:rotate-90" />
+                            <ChevronRight className="h-4 w-4 text-gray-400 transition group-open:rotate-90 dark:text-gray-500" />
                           </summary>
                           <div className="max-h-64 space-y-1 overflow-y-auto px-1 pb-3">
                             {myProjects.map((project) => {
@@ -208,7 +228,7 @@ export function Layout({ children }: LayoutProps) {
                                 <Link
                                   key={`my-${id}`}
                                   to={`/projects/${encodeURIComponent(id)}`}
-                                  className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-700"
+                                  className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-200 dark:hover:bg-slate-700 dark:hover:text-blue-200"
                                 >
                                   <Star className="mr-2 h-4 w-4 text-amber-500" />
                                   <span className="truncate">{project.name || id}</span>
@@ -220,10 +240,10 @@ export function Layout({ children }: LayoutProps) {
                       )}
 
                       {allProjects.length > 0 && (
-                        <details className="group rounded-md border border-gray-200 bg-white">
-                          <summary className="flex cursor-pointer items-center justify-between px-3 py-2 text-sm font-medium text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400">
+                        <details className="group rounded-md border border-gray-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+                          <summary className="flex cursor-pointer items-center justify-between px-3 py-2 text-sm font-medium text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:text-gray-200">
                             <span>All Projects</span>
-                            <ChevronRight className="h-4 w-4 text-gray-400 transition group-open:rotate-90" />
+                            <ChevronRight className="h-4 w-4 text-gray-400 transition group-open:rotate-90 dark:text-gray-500" />
                           </summary>
                           <div className="max-h-64 space-y-1 overflow-y-auto px-1 pb-3">
                             {allProjects.map((project) => {
@@ -233,7 +253,7 @@ export function Layout({ children }: LayoutProps) {
                                 <Link
                                   key={`all-${id}`}
                                   to={`/projects/${encodeURIComponent(id)}`}
-                                  className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-700"
+                                  className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-200 dark:hover:bg-slate-700 dark:hover:text-blue-200"
                                 >
                                   <Folder className="mr-2 h-4 w-4 text-blue-500" />
                                   <span className="truncate">{project.name || id}</span>
@@ -245,13 +265,16 @@ export function Layout({ children }: LayoutProps) {
                       )}
 
                       {myProjects.length === 0 && allProjects.length === 0 && (
-                        <p className="px-3 text-xs text-gray-500">No projects available.</p>
+                        <p className="px-3 text-xs text-gray-500 dark:text-gray-400">No projects available.</p>
                       )}
                     </>
                   )}
                 </div>
                 <div className="mt-3 px-3">
-                  <Link to="/projects" className="inline-flex items-center text-xs font-medium text-blue-600 hover:text-blue-500">
+                  <Link
+                    to="/projects"
+                    className="inline-flex items-center text-xs font-medium text-blue-600 hover:text-blue-500 dark:text-blue-300 dark:hover:text-blue-200"
+                  >
                     Manage projects
                     <ChevronRight className="ml-1 h-3 w-3" />
                   </Link>
@@ -260,7 +283,9 @@ export function Layout({ children }: LayoutProps) {
 
               {savedSearches.length > 0 && (
                 <div>
-                  <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Saved Searches</p>
+                  <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Saved Searches
+                  </p>
                   <div className="mt-3 space-y-1">
                     {savedSearches.map((search) => {
                       const savedId = search.ID || search.id;
@@ -269,7 +294,7 @@ export function Layout({ children }: LayoutProps) {
                         <Link
                           key={`saved-${savedId}`}
                           to={{ pathname: '/search', search: new URLSearchParams({ saved: savedId.toString() }).toString() }}
-                          className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                          className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                         >
                           <Search className="mr-2 h-4 w-4 text-emerald-500" />
                           <span className="truncate">{search.title || search.description || savedId.toString()}</span>
@@ -281,32 +306,34 @@ export function Layout({ children }: LayoutProps) {
               )}
 
               <div>
-                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Create New</p>
+                <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Create New
+                </p>
                 <div className="mt-3 space-y-1">
                   <Link
                     to="/projects"
-                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                   >
                     <Plus className="mr-2 h-4 w-4 text-blue-500" />
                     Project
                   </Link>
                   <Link
                     to="/subjects"
-                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                   >
                     <Plus className="mr-2 h-4 w-4 text-blue-500" />
                     Subject
                   </Link>
                   <Link
                     to="/experiments"
-                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                   >
                     <Plus className="mr-2 h-4 w-4 text-blue-500" />
                     Experiment
                   </Link>
                   <Link
                     to="/upload"
-                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                    className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                   >
                     <Plus className="mr-2 h-4 w-4 text-blue-500" />
                     Upload Session
@@ -316,18 +343,20 @@ export function Layout({ children }: LayoutProps) {
 
               {isAdmin && (
                 <div>
-                  <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Admin Tools</p>
+                  <p className="px-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Admin Tools
+                  </p>
                   <div className="mt-3 space-y-1">
                     <Link
                       to="/admin/users"
-                      className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                      className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                     >
                       <ShieldCheck className="mr-2 h-4 w-4 text-purple-500" />
                       User Administration
                     </Link>
                     <Link
                       to="/settings"
-                      className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                      className="flex items-center rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-slate-800 dark:hover:text-white"
                     >
                       <Settings className="mr-2 h-4 w-4 text-gray-500" />
                       Site Settings
@@ -342,47 +371,47 @@ export function Layout({ children }: LayoutProps) {
               <div className="px-4 py-2">
                 <button
                   onClick={openXnat}
-                  className="flex items-center w-full px-3 py-2 rounded-md text-sm font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-700 transition-colors"
+                  className="flex w-full items-center rounded-md px-3 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-blue-50 hover:text-blue-700 dark:text-blue-300 dark:hover:bg-slate-800 dark:hover:text-blue-200"
                 >
-                  <ExternalLink className="w-4 h-4 mr-3" />
+                  <ExternalLink className="mr-3 h-4 w-4" />
                   Open XNAT
                 </button>
               </div>
             )}
-            
+
             {/* User info at bottom */}
-            <div className="px-4 py-4 border-t border-gray-200">
-              <div className="text-xs text-gray-500 mb-2">
+            <div className="border-t border-gray-200 px-4 py-4 dark:border-slate-800">
+              <div className="mb-2 text-xs text-gray-500 dark:text-gray-400">
                 {config?.baseURL && new URL(config.baseURL).hostname}
               </div>
               <div className="relative group">
-                <button className="flex items-center w-full text-sm rounded-lg p-2 bg-gray-50 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500">
-                  <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center mr-3">
-                    <User className="w-4 h-4 text-gray-600" />
+                <button className="flex w-full items-center rounded-lg bg-gray-50 p-2 text-sm hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-slate-800 dark:hover:bg-slate-700">
+                  <div className="mr-3 flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 dark:bg-slate-700">
+                    <User className="h-4 w-4 text-gray-600 dark:text-gray-200" />
                   </div>
                   <div className="flex-1 text-left">
-                    <div className="text-sm font-medium text-gray-900">
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
                       {currentUser?.firstname} {currentUser?.lastname}
                     </div>
-                    <div className="text-xs text-gray-500 truncate">
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
                       {currentUser?.email}
                     </div>
                   </div>
                 </button>
-                
-                <div className="absolute bottom-full left-0 mb-2 w-full bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
+
+                <div className="invisible absolute bottom-full left-0 z-50 mb-2 w-full rounded-md bg-white py-1 opacity-0 shadow-lg ring-1 ring-black ring-opacity-5 transition-all duration-200 group-hover:visible group-hover:opacity-100 dark:bg-slate-900 dark:text-gray-100 dark:ring-white/10">
                   <Link
                     to="/settings"
-                    className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-slate-800"
                   >
-                    <Settings className="w-4 h-4 mr-3" />
+                    <Settings className="mr-3 h-4 w-4" />
                     Settings
                   </Link>
                   <button
                     onClick={handleLogout}
-                    className="flex items-center w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    className="flex w-full items-center px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-slate-800"
                   >
-                    <LogOut className="w-4 h-4 mr-3" />
+                    <LogOut className="mr-3 h-4 w-4" />
                     Sign out
                   </button>
                 </div>
@@ -396,50 +425,73 @@ export function Layout({ children }: LayoutProps) {
       <div className="flex-1 flex flex-col relative">
 
         {/* Top Header */}
-        <header className="bg-white shadow-sm border-b border-gray-200 flex-shrink-0">
+        <header className="flex-shrink-0 border-b border-gray-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <div className="px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center h-16">
+            <div className="flex h-16 items-center justify-between">
               {/* Mobile menu and logo (shown on small screens) */}
-              <div className="md:hidden flex items-center">
-                <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
-                  <span className="text-white font-bold text-sm">X</span>
+              <div className="flex items-center md:hidden">
+                <div className="mr-3 flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600">
+                  <span className="text-sm font-bold text-white">X</span>
                 </div>
-                <span className="text-xl font-bold text-gray-900">XNAT Portal</span>
+                <span className="text-xl font-bold text-gray-900 dark:text-gray-100">XNAT Portal</span>
               </div>
-              
+
               {/* Desktop: Just user menu */}
               <div className="hidden md:flex md:ml-auto md:items-center md:space-x-4">
-                <div className="text-sm text-gray-500">
+                <div className="flex items-center space-x-2">
+                  <label
+                    htmlFor="theme-select"
+                    className="flex items-center gap-2 text-sm font-medium text-gray-500 dark:text-gray-300"
+                  >
+                    {theme === 'dark' ? (
+                      <Moon className="h-4 w-4" />
+                    ) : (
+                      <Sun className="h-4 w-4" />
+                    )}
+                    <span>Theme</span>
+                  </label>
+                  <select
+                    id="theme-select"
+                    value={theme}
+                    onChange={handleThemeChange}
+                    className="rounded-md border border-gray-200 bg-white py-1.5 pl-2 pr-8 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400"
+                  >
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                  </select>
+                </div>
+
+                <div className="text-sm text-gray-500 dark:text-gray-300">
                   {config?.baseURL && new URL(config.baseURL).hostname}
                 </div>
-                
+
                 <div className="relative group">
-                  <button className="flex items-center text-sm rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                  <button className="flex items-center rounded-full bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-slate-800 dark:text-gray-100 dark:focus:ring-offset-slate-900">
                     <span className="sr-only">Open user menu</span>
-                    <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center">
-                      <User className="w-4 h-4 text-gray-600" />
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 dark:bg-slate-700">
+                      <User className="h-4 w-4 text-gray-600 dark:text-gray-200" />
                     </div>
-                    <span className="ml-2 text-gray-700 font-medium">
+                    <span className="ml-2 font-medium text-gray-700 dark:text-gray-100">
                       {currentUser?.firstname} {currentUser?.lastname}
                     </span>
                   </button>
-                  
-                  <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                    <div className="px-4 py-2 text-sm text-gray-500 border-b border-gray-100">
+
+                  <div className="invisible absolute right-0 z-50 mt-2 w-48 rounded-md bg-white py-1 opacity-0 shadow-lg ring-1 ring-black ring-opacity-5 transition-all duration-200 group-hover:visible group-hover:opacity-100 dark:bg-slate-900 dark:text-gray-100 dark:ring-white/10">
+                    <div className="border-b border-gray-100 px-4 py-2 text-sm text-gray-500 dark:border-slate-800 dark:text-gray-300">
                       {currentUser?.email}
                     </div>
                     <Link
                       to="/settings"
-                      className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-slate-800"
                     >
-                      <Settings className="w-4 h-4 mr-3" />
+                      <Settings className="mr-3 h-4 w-4" />
                       Settings
                     </Link>
                     <button
                       onClick={handleLogout}
-                      className="flex items-center w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="flex w-full items-center px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-slate-800"
                     >
-                      <LogOut className="w-4 h-4 mr-3" />
+                      <LogOut className="mr-3 h-4 w-4" />
                       Sign out
                     </button>
                   </div>
@@ -449,28 +501,28 @@ export function Layout({ children }: LayoutProps) {
               {/* Mobile user menu */}
               <div className="md:hidden">
                 <div className="relative group">
-                  <button className="flex items-center text-sm rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-                    <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center">
-                      <User className="w-4 h-4 text-gray-600" />
+                  <button className="flex items-center rounded-full bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-slate-800 dark:text-gray-100 dark:focus:ring-offset-slate-900">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 dark:bg-slate-700">
+                      <User className="h-4 w-4 text-gray-600 dark:text-gray-200" />
                     </div>
                   </button>
-                  
-                  <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                    <div className="px-4 py-2 text-sm text-gray-500 border-b border-gray-100">
+
+                  <div className="invisible absolute right-0 z-50 mt-2 w-48 rounded-md bg-white py-1 opacity-0 shadow-lg ring-1 ring-black ring-opacity-5 transition-all duration-200 group-hover:visible group-hover:opacity-100 dark:bg-slate-900 dark:text-gray-100 dark:ring-white/10">
+                    <div className="border-b border-gray-100 px-4 py-2 text-sm text-gray-500 dark:border-slate-800 dark:text-gray-300">
                       {currentUser?.email}
                     </div>
                     <Link
                       to="/settings"
-                      className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-slate-800"
                     >
-                      <Settings className="w-4 h-4 mr-3" />
+                      <Settings className="mr-3 h-4 w-4" />
                       Settings
                     </Link>
                     <button
                       onClick={handleLogout}
-                      className="flex items-center w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="flex w-full items-center px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-slate-800"
                     >
-                      <LogOut className="w-4 h-4 mr-3" />
+                      <LogOut className="mr-3 h-4 w-4" />
                       Sign out
                     </button>
                   </div>
@@ -482,7 +534,7 @@ export function Layout({ children }: LayoutProps) {
 
         {/* Mobile Navigation */}
         {!isViewerRoute && (
-          <div className="md:hidden bg-white border-b border-gray-200">
+          <div className="md:hidden border-b border-gray-200 bg-white dark:border-slate-800 dark:bg-slate-900">
             <nav className="px-4 py-2 space-y-1">
               {navigation.map((item) => {
                 const isActive = location.pathname === item.href;
@@ -491,17 +543,39 @@ export function Layout({ children }: LayoutProps) {
                     key={item.name}
                     to={item.href}
                     className={clsx(
-                      'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
+                      'flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors',
                       isActive
-                        ? 'bg-blue-100 text-blue-700'
-                        : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-200'
+                        : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-slate-800 dark:hover:text-white'
                     )}
                   >
-                    <item.icon className="w-4 h-4 mr-3" />
+                    <item.icon className="mr-3 h-4 w-4" />
                     {item.name}
                   </Link>
                 );
               })}
+              <div className="pt-3">
+                <label
+                  htmlFor="mobile-theme-select"
+                  className="mb-1 flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300"
+                >
+                  {theme === 'dark' ? (
+                    <Moon className="h-4 w-4" />
+                  ) : (
+                    <Sun className="h-4 w-4" />
+                  )}
+                  <span>Theme</span>
+                </label>
+                <select
+                  id="mobile-theme-select"
+                  value={theme}
+                  onChange={handleThemeChange}
+                  className="w-full rounded-md border border-gray-200 bg-white py-2 pl-2 pr-8 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
             </nav>
           </div>
         )}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,90 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  setTheme: (theme: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'xnat-theme';
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemeMode>('light');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const storedTheme = window.localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      setThemeState(storedTheme);
+      return;
+    }
+
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setThemeState('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((nextTheme: ThemeMode) => {
+    setThemeState(nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((previous) => (previous === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [setTheme, theme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,21 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  html.dark {
+    color-scheme: dark;
+  }
+
+  body {
+    @apply bg-gray-50 text-gray-900 antialiased;
+  }
+
+  html.dark body {
+    @apply bg-slate-950 text-gray-100;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- add a shared theme provider that stores the active theme and toggles the document dark class
- surface light/dark selectors in the layout header and mobile navigation while updating global styling for dark mode
- enable Tailwind's class-based dark mode and adjust layout styles to render correctly in both themes

## Testing
- npm run build *(fails: existing type errors in Dashboard and LegacyIndex complaining about nullable client and JSX namespace)*

## Screenshots
![Login screen showing default theme](browser:/invocations/tzlsktgy/artifacts/artifacts/theme-selector-login.png)


------
https://chatgpt.com/codex/tasks/task_e_68dd64a45cb48321a7e2ee9e5ca6d67f