### PR TITLE
Improve dark mode text contrast

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -68,5 +68,61 @@ html.dark body {
   .dark .text-gray-500 {
     @apply text-gray-400;
   }
+
+  .dark .text-slate-900,
+  .dark .text-slate-800 {
+    @apply text-slate-100;
+  }
+
+  .dark .text-slate-700 {
+    @apply text-slate-200;
+  }
+
+  .dark .text-blue-900,
+  .dark .text-blue-800 {
+    @apply text-blue-200;
+  }
+
+  .dark .text-blue-700 {
+    @apply text-blue-300;
+  }
+
+  .dark .text-green-900,
+  .dark .text-green-800 {
+    @apply text-green-200;
+  }
+
+  .dark .text-green-700 {
+    @apply text-green-300;
+  }
+
+  .dark .text-red-900,
+  .dark .text-red-800 {
+    @apply text-red-200;
+  }
+
+  .dark .text-red-700 {
+    @apply text-red-300;
+  }
+
+  .dark .text-yellow-800 {
+    @apply text-yellow-200;
+  }
+
+  .dark .text-yellow-700 {
+    @apply text-yellow-300;
+  }
+
+  .dark .text-amber-700 {
+    @apply text-amber-300;
+  }
+
+  .dark .text-cyan-700 {
+    @apply text-cyan-300;
+  }
+
+  .dark .text-purple-700 {
+    @apply text-purple-300;
+  }
 }
 }


### PR DESCRIPTION
## Summary
- add dark mode utility overrides to remap dark text colors to lighter hues
- ensure slate, blue, green, red, yellow, amber, cyan, and purple variants stay legible against dark backgrounds

## Testing
- `npm run build` *(fails: existing TypeScript nullability and JSX namespace errors in Dashboard.tsx and LegacyIndex.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd794a609c8321b8f3e23e729fce02