### PR TITLE
Add scan snapshot thumbnails to scans views

### DIFF
--- a/src/components/ExperimentDetail.tsx
+++ b/src/components/ExperimentDetail.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useXnat } from '../contexts/XnatContext';
-import { 
+import {
   ArrowLeft,
   Calendar,
   User,
@@ -13,6 +13,7 @@ import {
   Eye,
   Monitor
 } from 'lucide-react';
+import { ScanSnapshot } from './ScanSnapshot';
 
 export function ExperimentDetail() {
   const { project, subject, experiment } = useParams<{
@@ -203,24 +204,36 @@ export function ExperimentDetail() {
             
             {scans && scans.length > 0 ? (
               <div className="space-y-3">
-                {scans.slice(0, 5).map((scan: any) => (
-                  <div key={scan.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                    <div className="flex items-center">
-                      <FileImage className="h-5 w-5 text-gray-400 mr-3" />
-                      <div>
-                        <div className="text-sm font-medium text-gray-900">
-                          {scan.series_description || `Scan ${scan.id}`}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          {scan.type} • {scan.quality}
+                {scans.slice(0, 5).map((scan: any) => {
+                  const snapshotUrl =
+                    client && project && subject && experiment
+                      ? client.getScanThumbnailUrl(project, subject, experiment, scan.id)
+                      : null;
+
+                  return (
+                    <div key={scan.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                      <div className="flex items-center min-w-0">
+                        <ScanSnapshot
+                          snapshotUrl={snapshotUrl}
+                          alt={`Snapshot of ${scan.series_description || `Scan ${scan.id}`}`}
+                          containerClassName="h-16 w-24 mr-3 flex-shrink-0"
+                        />
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium text-gray-900 truncate">
+                            {scan.series_description || `Scan ${scan.id}`}
+                          </div>
+                          <div className="text-xs text-gray-500">
+                            {scan.type} • {scan.quality || 'Unknown quality'}
+                          </div>
                         </div>
                       </div>
+                      <div className="text-xs text-gray-500 text-right">
+                        <div>{scan.frames ? `${scan.frames} frames` : ''}</div>
+                        <div className="text-[10px] text-gray-400">{scan.id}</div>
+                      </div>
                     </div>
-                    <div className="text-xs text-gray-500">
-                      {scan.frames ? `${scan.frames} frames` : ''}
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
                 
                 {scans.length > 5 && (
                   <div className="text-center pt-2">

--- a/src/components/ScanSnapshot.tsx
+++ b/src/components/ScanSnapshot.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { Image as ImageIcon } from 'lucide-react';
+
+interface ScanSnapshotProps {
+  snapshotUrl?: string | null;
+  alt: string;
+  containerClassName?: string;
+  imageClassName?: string;
+  iconClassName?: string;
+  showLabel?: boolean;
+}
+
+export function ScanSnapshot({
+  snapshotUrl,
+  alt,
+  containerClassName,
+  imageClassName,
+  iconClassName,
+  showLabel = false,
+}: ScanSnapshotProps) {
+  const [hasError, setHasError] = useState(!snapshotUrl);
+
+  useEffect(() => {
+    setHasError(!snapshotUrl);
+  }, [snapshotUrl]);
+
+  return (
+    <div
+      className={clsx(
+        'relative overflow-hidden rounded-md bg-gray-100 flex items-center justify-center',
+        containerClassName ?? 'w-full h-40'
+      )}
+    >
+      {snapshotUrl && !hasError ? (
+        <img
+          src={snapshotUrl}
+          alt={alt}
+          className={clsx('h-full w-full object-cover', imageClassName)}
+          loading="lazy"
+          onError={() => setHasError(true)}
+        />
+      ) : (
+        <div className="flex flex-col items-center justify-center text-gray-400">
+          <ImageIcon className={clsx('h-10 w-10', iconClassName)} />
+          {showLabel && (
+            <span className="mt-2 text-xs font-medium">Snapshot unavailable</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Scans.tsx
+++ b/src/components/Scans.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useXnat } from '../contexts/XnatContext';
-import { 
+import {
   ArrowLeft,
   FileImage,
   Download,
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import clsx from 'clsx';
+import { ScanSnapshot } from './ScanSnapshot';
 
 export function Scans() {
   const { project, subject, experiment } = useParams<{
@@ -217,79 +218,93 @@ export function Scans() {
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredScans.map((scan: any) => (
-            <div
-              key={scan.id}
-              className="relative group bg-white rounded-lg shadow hover:shadow-md transition-shadow"
-            >
-              <div className="p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center">
-                    <div className="h-10 w-10 bg-blue-100 rounded-lg flex items-center justify-center">
-                      <ImageIcon className="h-5 w-5 text-blue-600" />
-                    </div>
-                    <div className="ml-3">
-                      <h3 className="text-sm font-medium text-gray-900 truncate">
-                        {scan.series_description || `Scan ${scan.id}`}
-                      </h3>
-                      <p className="text-xs text-gray-500">{scan.id}</p>
-                    </div>
-                  </div>
-                  
-                  {scan.quality && (
-                    <span className={clsx(
-                      'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium',
-                      getQualityColor(scan.quality)
-                    )}>
-                      <Activity className="h-3 w-3 mr-1" />
-                      {scan.quality}
-                    </span>
-                  )}
-                </div>
+          {filteredScans.map((scan: any) => {
+            const snapshotUrl =
+              client && project && subject && experiment
+                ? client.getScanThumbnailUrl(project, subject, experiment, scan.id)
+                : null;
 
-                <div className="space-y-2 mb-4">
-                  {scan.type && (
-                    <div className="flex items-center text-sm text-gray-600">
-                      <FileImage className="h-4 w-4 mr-2 text-gray-400" />
-                      <span className="truncate">{scan.type}</span>
-                    </div>
-                  )}
-                  
-                  {scan.frames && (
-                    <div className="flex items-center text-sm text-gray-600">
-                      <HardDrive className="h-4 w-4 mr-2 text-gray-400" />
-                      <span>{scan.frames} frames</span>
-                    </div>
-                  )}
-                  
-                  {scan.note && (
-                    <div className="text-sm text-gray-600">
-                      <span className="font-medium">Note:</span> {scan.note}
-                    </div>
-                  )}
-                </div>
+            return (
+              <div
+                key={scan.id}
+                className="relative group bg-white rounded-lg shadow hover:shadow-md transition-shadow"
+              >
+                <div className="p-6">
+                  <ScanSnapshot
+                    snapshotUrl={snapshotUrl}
+                    alt={`Snapshot of ${scan.series_description || `Scan ${scan.id}`}`}
+                    containerClassName="w-full h-40 mb-4"
+                    showLabel
+                  />
 
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-2">
-                    <button className="inline-flex items-center text-xs font-medium text-blue-600 hover:text-blue-500">
-                      <Eye className="h-3 w-3 mr-1" />
-                      View
-                    </button>
-                    
-                    <button className="inline-flex items-center text-xs font-medium text-green-600 hover:text-green-500">
-                      <Download className="h-3 w-3 mr-1" />
-                      Download
-                    </button>
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center">
+                      <div className="h-10 w-10 bg-blue-100 rounded-lg flex items-center justify-center">
+                        <ImageIcon className="h-5 w-5 text-blue-600" />
+                      </div>
+                      <div className="ml-3">
+                        <h3 className="text-sm font-medium text-gray-900 truncate">
+                          {scan.series_description || `Scan ${scan.id}`}
+                        </h3>
+                        <p className="text-xs text-gray-500">{scan.id}</p>
+                      </div>
+                    </div>
+
+                    {scan.quality && (
+                      <span className={clsx(
+                        'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium',
+                        getQualityColor(scan.quality)
+                      )}>
+                        <Activity className="h-3 w-3 mr-1" />
+                        {scan.quality}
+                      </span>
+                    )}
                   </div>
-                  
-                  <div className="flex items-center text-xs text-gray-500">
-                    <Clock className="h-3 w-3 mr-1" />
-                    {scan.startTime || 'No time'}
+
+                  <div className="space-y-2 mb-4">
+                    {scan.type && (
+                      <div className="flex items-center text-sm text-gray-600">
+                        <FileImage className="h-4 w-4 mr-2 text-gray-400" />
+                        <span className="truncate">{scan.type}</span>
+                      </div>
+                    )}
+
+                    {scan.frames && (
+                      <div className="flex items-center text-sm text-gray-600">
+                        <HardDrive className="h-4 w-4 mr-2 text-gray-400" />
+                        <span>{scan.frames} frames</span>
+                      </div>
+                    )}
+
+                    {scan.note && (
+                      <div className="text-sm text-gray-600">
+                        <span className="font-medium">Note:</span> {scan.note}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-2">
+                      <button className="inline-flex items-center text-xs font-medium text-blue-600 hover:text-blue-500">
+                        <Eye className="h-3 w-3 mr-1" />
+                        View
+                      </button>
+
+                      <button className="inline-flex items-center text-xs font-medium text-green-600 hover:text-green-500">
+                        <Download className="h-3 w-3 mr-1" />
+                        Download
+                      </button>
+                    </div>
+
+                    <div className="flex items-center text-xs text-gray-500">
+                      <Clock className="h-3 w-3 mr-1" />
+                      {scan.startTime || 'No time'}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/src/services/xnat-api.ts
+++ b/src/services/xnat-api.ts
@@ -553,6 +553,18 @@ export class XnatApiClient {
     return [];
   }
 
+  private resolveBaseUrl(): string {
+    const base = this.client.defaults.baseURL ?? this.config.baseURL ?? '';
+    if (!base) return '';
+    return base.endsWith('/') ? base.slice(0, -1) : base;
+  }
+
+  private buildUrl(path: string): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    const base = this.resolveBaseUrl();
+    return base ? `${base}${normalizedPath}` : normalizedPath;
+  }
+
   private normalizeUserRecord(raw: UnknownRecord): XnatUser {
     const username = this.extractString(raw, ['username', 'login', 'LOGIN']) || '';
     const numericId = this.extractNumber(raw, ['xdat_user_id', 'id', 'ID', 'userId']);
@@ -1001,6 +1013,11 @@ export class XnatApiClient {
       params: { format: 'json' }
     });
     return response.data.ResultSet?.Result || [];
+  }
+
+  getScanThumbnailUrl(projectId: string, subjectId: string, experimentId: string, scanId: string): string {
+    const path = `/data/projects/${projectId}/subjects/${subjectId}/experiments/${experimentId}/scans/${scanId}/thumbnail`;
+    return this.buildUrl(path);
   }
 
   async getScan(projectId: string, subjectId: string, experimentId: string, scanId: string): Promise<XnatScan> {


### PR DESCRIPTION
## Summary
- add a reusable ScanSnapshot component with graceful fallback styling
- render scan thumbnail imagery on experiment details and the scans listing grid
- expose a helper on the API client for constructing thumbnail URLs

## Testing
- npm run build *(fails: existing TypeScript issues in CompressedUploader, Dashboard, LegacyIndex, and dcmjs-anonymizer)*

------
https://chatgpt.com/codex/tasks/task_e_68df28c498d88321b3131479db9be781