### PR TITLE
Fix DICOM tag formatting in anonymization manifest

### DIFF
--- a/src/services/dicom-anonymizer.ts
+++ b/src/services/dicom-anonymizer.ts
@@ -258,6 +258,7 @@ export class DicomAnonymizer {
       'ClinicalTrialSubjectReadingID': '00120042',
       'ClinicalTrialTimePointID': '00120050',
       'ClinicalTrialTimePointDescription': '00120051',
+      'DeidentificationMethod': '00120063',
     };
 
     // Check if it's a naturalized name
@@ -272,8 +273,8 @@ export class DicomAnonymizer {
       return cleaned.toUpperCase();
     }
 
-    // Unknown format - return as is
-    return tag;
+    // Unknown format - return placeholder
+    return '00000000';
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixed DICOM tag formatting to display hex values instead of naturalized names in anonymization manifest
- Added `DeidentificationMethod` (0012,0063) to the tag name mapping
- Changed fallback behavior for unknown tags to use placeholder hex value

## Changes
- **dicom-anonymizer.ts**: Added `DeidentificationMethod` to `nameToHexMap`
- **dicom-anonymizer.ts**: Changed unknown format fallback from returning raw tag to `00000000` placeholder

## Test plan
- [x] Upload DICOM files and verify anonymization manifest displays tags in hex format `(XXXX,XXXX)`
- [x] Verify `DeidentificationMethod` now shows as `(0012,0063)` instead of `(Deid,entificationMethod)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)