### PR TITLE
Fix DICOM viewers session lookup

### DIFF
--- a/src/contexts/XnatContext.tsx
+++ b/src/contexts/XnatContext.tsx
@@ -20,7 +20,7 @@ interface XnatProviderProps {
   children: ReactNode;
 }
 
-const STORAGE_KEYS = {
+export const STORAGE_KEYS = {
   CONFIG: 'xnat_config',
   JSESSIONID: 'xnat_jsessionid',
   USER: 'xnat_user',


### PR DESCRIPTION
## Summary
- export the stored authentication key names from the Xnat context
- update the Cornerstone and simple DICOM viewers to pull the stored JSESSIONID when fetching scan files
- ensure viewer fetches include credentials so authenticated sessions reach the proxy

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a87f5d748321b45b1ed37ec746fc